### PR TITLE
Add github auth commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 *.log
+*.gz
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ ext {
 	set('antVersion', '1.10.9')
 	set('mavenModelVersion', '3.5.4')
 	set('tikaVersion', '1.18')
+	set('jimfsVersion', '1.2')
 }
 
 configurations.all {
@@ -38,6 +39,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation "org.springframework.shell:spring-shell-starter-jna"
 	implementation 'io.spring.initializr:initializr-generator'
+	implementation 'io.projectreactor.addons:reactor-extra'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 	implementation 'org.rauschig:jarchivelib'
 	implementation 'org.kohsuke:github-api'
 	implementation 'org.gitlab4j:gitlab4j-api'
@@ -48,6 +51,7 @@ dependencies {
 	implementation 'org.apache.tika:tika-core'
 	compileOnly 'org.springframework.experimental:spring-aot'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.google.jimfs:jimfs'
 }
 
 dependencyManagement {
@@ -62,6 +66,7 @@ dependencyManagement {
 		dependency "org.apache.ant:ant:${antVersion}"
 		dependency "org.apache.maven:maven-model:${mavenModelVersion}"
 		dependency "org.apache.tika:tika-core:${tikaVersion}"
+		dependency "com.google.jimfs:jimfs:${jimfsVersion}"
 	}
 	imports {
 		mavenBom "org.springframework.shell:spring-shell-dependencies:${springShellVersion}"

--- a/src/main/java/org/springframework/up/command/GithubCommands.java
+++ b/src/main/java/org/springframework/up/command/GithubCommands.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.up.command;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jline.utils.AttributedString;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.shell.standard.ShellComponent;
+import org.springframework.shell.standard.ShellMethod;
+import org.springframework.shell.standard.ShellOption;
+import org.springframework.shell.style.ThemeSettings;
+import org.springframework.up.support.AbstractUpCliCommands;
+import org.springframework.up.support.ComponentFlow;
+import org.springframework.up.support.ComponentFlow.ComponentFlowResult;
+import org.springframework.up.support.ComponentFlow.ResultMode;
+import org.springframework.up.support.UpCliUserConfig;
+import org.springframework.up.support.UpCliUserConfig.Host;
+import org.springframework.up.support.UpCliUserConfig.Hosts;
+import org.springframework.up.support.github.GithubDeviceFlow;
+import org.springframework.up.support.Wizard;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Commands for github authentication.
+ *
+ * @author Janne Valkealahti
+ */
+@ShellComponent
+public class GithubCommands extends AbstractUpCliCommands {
+
+	private final static Logger log = LoggerFactory.getLogger(GithubCommands.class);
+
+	@Autowired
+	private WebClient.Builder webClientBuilder;
+
+	@Autowired
+	private UpCliUserConfig userConfig;
+
+	/**
+	 * Login command for github. Makes user to choose either starting a device flow
+	 * via browser or pasting a token created manually.
+	 */
+	@ShellMethod(key = "github auth login", value = "Authenticate with a GitHub")
+	public void login() {
+		String authType = askAuthType();
+		String clientId = getCliProperties().getGithub().getClientId();
+		String scopes = getCliProperties().getGithub().getDefaultScopes();
+
+		if (ObjectUtils.nullSafeEquals(authType, "web")) {
+			Map<String, String> response = GithubDeviceFlow.requestDeviceFlow(webClientBuilder, clientId, scopes);
+
+			AttributedString styledStr = styledString("!", ThemeSettings.TAG_LEVEL_WARN);
+			styledStr = join(styledStr,
+					styledString(" Open browser with https://github.com/login/device and paste device code ", null));
+			styledStr = join(styledStr, styledString(response.get("user_code"), ThemeSettings.TAG_HIGHLIGHT));
+			shellPrint(styledStr);
+
+			String token = GithubDeviceFlow.waitTokenFromDeviceFlow(webClientBuilder, clientId,
+					response.get("device_code"),
+					Integer.parseInt(response.get("expires_in")),
+					Integer.parseInt(response.get("interval")));
+			userConfig.updateHost("github.com", new Host(token, null));
+			shellPrint("logged in to github");
+		}
+		else if (ObjectUtils.nullSafeEquals(authType, "paste")) {
+			shellPrint("Tip: you can generate a Personal Access Token here https://github.com/settings/tokens");
+			shellPrint("The minimum required scopes are 'repo', 'read:org'");
+			String token = askToken();
+			userConfig.updateHost("github.com", new Host(token, null));
+			shellPrint("logged in to github");
+		}
+	}
+
+	/**
+	 * Logout command which essentially removes local token if exists.
+	 */
+	@ShellMethod(key = "github auth logout", value = "Log out of a GitHub")
+	public void logout() {
+		Host host = null;
+		Map<String, Host> hostsMap = userConfig.getHosts();
+		if (hostsMap == null) {
+			hostsMap = new HashMap<>();
+		}
+		else {
+			host = hostsMap.get("github.com");
+		}
+		if (host == null) {
+			shellPrint("not logged in to github");
+		}
+		else {
+			hostsMap.remove("github.com");
+			Hosts hosts = new Hosts();
+			hosts.setHosts(hostsMap);
+			userConfig.setHosts(hosts);
+			shellPrint("removed authentication token");
+		}
+	}
+
+	/**
+	 * Shows current authentication status for a github.
+	 *
+	 * @param showToken flag if actual token should be shown.
+	 * @return the content
+	 */
+	@ShellMethod(key = "github auth status", value = "View authentication status")
+	public AttributedString status(
+			@ShellOption(help = "Display the auth token") boolean showToken
+		) {
+		Host host = null;
+		Map<String, Host> hosts = userConfig.getHosts();
+		if (hosts != null) {
+			host = hosts.get("github.com");
+		}
+		if (host == null) {
+			return new AttributedString("You are not logged into github");
+		}
+		else {
+			String loginName = null;
+			try {
+				GitHub gh = new GitHubBuilder().withOAuthToken(host.getOauthToken()).build();
+				loginName = gh.getMyself().getLogin();
+				log.debug("Got loginName {}", loginName);
+			} catch (IOException e) {
+				log.error("Error getting github login", e);
+			}
+			AttributedString ret = styledString("You are logged into github as ", null);
+			ret = join(ret, styledString(loginName, ThemeSettings.TAG_HIGHLIGHT));
+			if (showToken) {
+				ret = join(ret, styledString(", with token ", null));
+				ret = join(ret, styledString(host.getOauthToken(), ThemeSettings.TAG_HIGHLIGHT));
+			}
+			return ret;
+		}
+	}
+
+	/**
+	 * Asks if user wants to auth by giving a token or going through web flow.
+	 *
+	 * @return either web or paste
+	 */
+	private String askAuthType() {
+		Map<String, String> authType = new HashMap<>();
+		authType.put("Login with a web browser", "web");
+		authType.put("Paste an authentication token", "paste");
+		Wizard<ComponentFlowResult> wizard = ComponentFlow.builder(getTerminal())
+				.resourceLoader(getResourceLoader())
+				.templateExecutor(getTemplateExecutor())
+				.withSingleItemSelector("authType")
+					.name("How would you like to authenticate GitHub CLI")
+					.resultMode(ResultMode.ACCEPT)
+					.selectItems(authType)
+					.and()
+				.build();
+		ComponentFlowResult run = wizard.run();
+		return run.getContext().get("authType");
+	}
+
+	/**
+	 * Asks user to paste a token.
+	 *
+	 * @return token user gave
+	 */
+	private String askToken() {
+		Wizard<ComponentFlowResult> wizard = ComponentFlow.builder(getTerminal())
+				.resourceLoader(getResourceLoader())
+				.templateExecutor(getTemplateExecutor())
+				.withStringInput("token")
+					.name("Paste your authentication token:")
+					.maskCharacter('*')
+					.and()
+				.build();
+		ComponentFlowResult run = wizard.run();
+		return run.getContext().get("token");
+	}
+}

--- a/src/main/java/org/springframework/up/config/UpCliConfiguration.java
+++ b/src/main/java/org/springframework/up/config/UpCliConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorResourceFactory;
 import org.springframework.up.initializr.InitializrClient;
+import org.springframework.up.support.UpCliUserConfig;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /**
@@ -57,5 +58,10 @@ public class UpCliConfiguration {
 		return InitializrClient.builder(webClientBuilder)
 				.target(upCliProperties.getInitializr().getBaseUrl())
 				.build();
+	}
+
+	@Bean
+	public UpCliUserConfig upCliUserConfig() {
+		return new UpCliUserConfig();
 	}
 }

--- a/src/main/java/org/springframework/up/config/UpCliNativeConfiguration.java
+++ b/src/main/java/org/springframework/up/config/UpCliNativeConfiguration.java
@@ -24,6 +24,10 @@ import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
+import org.kohsuke.github.GHMyself;
+import org.kohsuke.github.GHObject;
+import org.kohsuke.github.GHPerson;
+import org.kohsuke.github.GHUser;
 
 import org.springframework.nativex.hint.FieldHint;
 import org.springframework.nativex.hint.JdkProxyHint;
@@ -204,6 +208,27 @@ import org.springframework.up.initializr.model.ProjectType.ProjectTypeValue;
 		),
 		@TypeHint(
 			typeNames = "org.jline.terminal.impl.jna.win.Kernel32$UnionChar",
+			access = {
+				TypeAccess.PUBLIC_CONSTRUCTORS, TypeAccess.DECLARED_CLASSES, TypeAccess.DECLARED_CONSTRUCTORS,
+				TypeAccess.DECLARED_FIELDS, TypeAccess.DECLARED_METHODS
+			}
+		),
+		@TypeHint(
+			typeNames = "org.springframework.up.support.UpCliUserConfig$Hosts",
+			access = {
+				TypeAccess.PUBLIC_CONSTRUCTORS, TypeAccess.DECLARED_CLASSES, TypeAccess.DECLARED_CONSTRUCTORS,
+				TypeAccess.DECLARED_FIELDS, TypeAccess.DECLARED_METHODS
+			}
+		),
+		@TypeHint(
+			typeNames = "org.springframework.up.support.UpCliUserConfig$Host",
+			access = {
+				TypeAccess.PUBLIC_CONSTRUCTORS, TypeAccess.DECLARED_CLASSES, TypeAccess.DECLARED_CONSTRUCTORS,
+				TypeAccess.DECLARED_FIELDS, TypeAccess.DECLARED_METHODS
+			}
+		),
+		@TypeHint(
+			types = { GHMyself.class, GHObject.class, GHPerson.class, GHUser.class },
 			access = {
 				TypeAccess.PUBLIC_CONSTRUCTORS, TypeAccess.DECLARED_CLASSES, TypeAccess.DECLARED_CONSTRUCTORS,
 				TypeAccess.DECLARED_FIELDS, TypeAccess.DECLARED_METHODS

--- a/src/main/java/org/springframework/up/config/UpCliProperties.java
+++ b/src/main/java/org/springframework/up/config/UpCliProperties.java
@@ -29,6 +29,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class UpCliProperties {
 
 	private Initializr initializr = new Initializr();
+	private Github github = new Github();
 
 	public Initializr getInitializr() {
 		return initializr;
@@ -36,6 +37,14 @@ public class UpCliProperties {
 
 	public void setInitializr(Initializr initializr) {
 		this.initializr = initializr;
+	}
+
+	public Github getGithub() {
+		return github;
+	}
+
+	public void setGithub(Github github) {
+		this.github = github;
 	}
 
 	/**
@@ -50,6 +59,36 @@ public class UpCliProperties {
 
 		public void setBaseUrl(String baseUrl) {
 			this.baseUrl = baseUrl;
+		}
+	}
+
+	public static class Github {
+
+		/**
+		 * OAuth client id for github oauth app which user is seeing when doing auth
+		 * flow. This is public so safe to expose.
+		 */
+		private String clientId;
+
+		/**
+		 * Default scopes auth flow requests from a user.
+		 */
+		private String defaultScopes = "repo,read:org";
+
+		public String getClientId() {
+			return clientId;
+		}
+
+		public void setClientId(String clientId) {
+			this.clientId = clientId;
+		}
+
+		public String getDefaultScopes() {
+			return defaultScopes;
+		}
+
+		public void setDefaultScopes(String defaultScopes) {
+			this.defaultScopes = defaultScopes;
 		}
 	}
 

--- a/src/main/java/org/springframework/up/support/AbstractUpCliCommands.java
+++ b/src/main/java/org/springframework/up/support/AbstractUpCliCommands.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.up.support;
+
+import java.util.Arrays;
+
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ApplicationContext;
+import org.springframework.shell.standard.AbstractShellComponent;
+import org.springframework.shell.style.ThemeResolver;
+import org.springframework.up.config.UpCliProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Base class for all cli commands.
+ *
+ * @author Janne Valkealahti
+ */
+public abstract class AbstractUpCliCommands extends AbstractShellComponent {
+
+    private ObjectProvider<UpCliProperties> cliPropertiesProvider;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		super.setApplicationContext(applicationContext);
+		this.cliPropertiesProvider = applicationContext.getBeanProvider(UpCliProperties.class);
+    }
+
+	protected UpCliProperties getCliProperties() {
+		return this.cliPropertiesProvider.getObject();
+	}
+
+	// TODO: when shell print commands mature, move those to AbstractShellComponent
+
+	protected void shellPrint(String... text) {
+		for (String t : text) {
+			getTerminal().writer().println(t);
+		}
+		shellFlush();
+	}
+
+	protected void shellPrint(AttributedString... text) {
+		for (AttributedString t : text) {
+			getTerminal().writer().println(t.toAnsi(getTerminal()));
+		}
+		shellFlush();
+	}
+
+	protected void shellFlush() {
+		getTerminal().writer().flush();
+	}
+
+	protected AttributedString styledString(String text, String tag) {
+		AttributedStyle style = null;
+		if (StringUtils.hasText(tag)) {
+			ThemeResolver themeResolver = getThemeResolver();
+			String resolvedStyle = themeResolver.resolveTag(tag);
+			style = themeResolver.resolveStyle(resolvedStyle);
+		}
+		return new AttributedString(text, style);
+	}
+
+	protected AttributedString join(AttributedString left, AttributedString right) {
+		return AttributedString.join(null, Arrays.asList(left, right));
+	}
+}

--- a/src/main/java/org/springframework/up/support/ComponentFlow.java
+++ b/src/main/java/org/springframework/up/support/ComponentFlow.java
@@ -147,6 +147,14 @@ public interface ComponentFlow extends Wizard<ComponentFlowResult> {
 		StringInputSpec defaultValue(String defaultValue);
 
 		/**
+		 * Sets a mask character.
+		 *
+		 * @param maskCharacter the mask character
+		 * @return a builder
+		 */
+		StringInputSpec maskCharacter(Character maskCharacter);
+
+		/**
 		 * Sets a renderer function.
 		 *
 		 * @param renderer the renderer
@@ -684,6 +692,7 @@ public interface ComponentFlow extends Wizard<ComponentFlowResult> {
 		private String resultValue;
 		private ResultMode resultMode;
 		private String defaultValue;
+		private Character maskCharacter;
 		private Function<StringInputContext, List<AttributedString>> renderer;
 		private List<Consumer<StringInputContext>> preHandlers = new ArrayList<>();
 		private List<Consumer<StringInputContext>> postHandlers = new ArrayList<>();
@@ -715,6 +724,12 @@ public interface ComponentFlow extends Wizard<ComponentFlowResult> {
 		@Override
 		public StringInputSpec defaultValue(String defaultValue) {
 			this.defaultValue = defaultValue;
+			return this;
+		}
+
+		@Override
+		public StringInputSpec maskCharacter(Character maskCharacter) {
+			this.maskCharacter = maskCharacter;
 			return this;
 		}
 
@@ -768,6 +783,10 @@ public interface ComponentFlow extends Wizard<ComponentFlowResult> {
 
 		public String getDefaultValue() {
 			return defaultValue;
+		}
+
+		public Character getMaskCharacter() {
+			return maskCharacter;
 		}
 
 		public Function<StringInputContext, List<AttributedString>> getRenderer() {
@@ -1319,6 +1338,7 @@ public interface ComponentFlow extends Wizard<ComponentFlowResult> {
 						StringInput selector = new StringInput(terminal, input.getName(), input.getDefaultValue());
 						selector.setResourceLoader(resourceLoader);
 						selector.setTemplateExecutor(templateExecutor);
+						selector.setMaskCharater(input.getMaskCharacter());
 						if (StringUtils.hasText(input.getTemplateLocation())) {
 							selector.setTemplateLocation(input.getTemplateLocation());
 						}

--- a/src/main/java/org/springframework/up/support/UpCliUserConfig.java
+++ b/src/main/java/org/springframework/up/support/UpCliUserConfig.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.up.support;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.springframework.up.support.configfile.UserConfig;
+
+/**
+ * Cli access point for user level stored settings.
+ *
+ * @author Janne Valkealahti
+ */
+public class UpCliUserConfig {
+
+	/**
+	 * Optional env variable for {@code SpringUp} configuration dir.
+	 */
+	public final static String SPRINGUP_CONFIG_DIR = "SPRINGUP_CONFIG_DIR";
+
+	/**
+	 * {@code hosts.yml} stores authentication spesific info for hosts.
+	 */
+	public final static String HOSTS = "hosts.yml";
+
+	/**
+	 * Base directory name we store our config files.
+	 */
+	private final static String SPRINGUP_CONFIG_NAME = "springup";
+
+	/**
+	 * Keeps auth tokens per hostname.
+	 */
+	private final UserConfig<Hosts> hostsConfigFile;
+
+	public UpCliUserConfig() {
+		this(null);
+	}
+
+	public UpCliUserConfig(Function<String, Path> pathProvider) {
+		this.hostsConfigFile = new UserConfig<>(HOSTS, Hosts.class, SPRINGUP_CONFIG_DIR, SPRINGUP_CONFIG_NAME);
+		if (pathProvider != null) {
+			this.hostsConfigFile.setPathProvider(pathProvider);
+		}
+	}
+
+	/**
+	 * Gets hosts.
+	 *
+	 * @return mappings for hosts
+	 */
+	public Map<String, Host> getHosts() {
+		Hosts hosts = hostsConfigFile.getConfig();
+		return hosts != null ? hosts.getHosts() : null;
+	}
+
+	/**
+	 * Sets hosts.
+	 *
+	 * @param the hosts
+	 */
+	public void setHosts(Hosts hosts) {
+		hostsConfigFile.setConfig(hosts);
+	}
+
+	/**
+	 * Update a single host.
+	 *
+	 * @param key the host key
+	 * @param host the host
+	 */
+	public void updateHost(String key, Host host) {
+		Map<String, Host> hostsMap = null;
+		Hosts hosts = hostsConfigFile.getConfig();
+		if (hosts != null) {
+			hostsMap = hosts.getHosts();
+		}
+		else {
+			hosts = new Hosts();
+		}
+		if (hostsMap == null) {
+			hostsMap = new HashMap<>();
+		}
+		hostsMap.put(key, host);
+		hosts.setHosts(hostsMap);
+		setHosts(hosts);
+	}
+
+	public static class Hosts {
+
+		private Map<String, Host> hosts = new HashMap<>();
+
+		public Map<String, Host> getHosts() {
+			return hosts;
+		}
+
+		public void setHosts(Map<String, Host> hosts) {
+			this.hosts = hosts;
+		}
+	}
+
+	public static class Host {
+
+		private String oauthToken;
+		private String user;
+
+		public Host() {
+		}
+
+		public Host(String oauthToken, String user) {
+			this.oauthToken = oauthToken;
+			this.user = user;
+		}
+
+		public static Host of(String oauthToken, String user) {
+			return new Host(oauthToken, user);
+		}
+
+		public String getOauthToken() {
+			return oauthToken;
+		}
+
+		public void setOauthToken(String oauthToken) {
+			this.oauthToken = oauthToken;
+		}
+
+		public String getUser() {
+			return user;
+		}
+
+		public void setUser(String user) {
+			this.user = user;
+		}
+	}
+}

--- a/src/main/java/org/springframework/up/support/configfile/ConfigFile.java
+++ b/src/main/java/org/springframework/up/support/configfile/ConfigFile.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.up.support.configfile;
+
+import java.nio.file.Path;
+
+/**
+ * Contract to read and write a config file. This contract doesn't care how
+ * things are stored as it's a decision for implementation but generally
+ * speaking interface expects one file per type which makes it easier to
+ * store complex types if/when needed.
+ *
+ * @author Janne Valkealahti
+ */
+public interface ConfigFile {
+
+	/**
+	 * Read typed mapped class from a config.
+	 *
+	 * @param <T> the type of a class to map
+	 * @param path the path to config file
+	 * @param type type of a class
+	 * @return deserialized content
+	 */
+	<T> T read(Path path, Class<T> type);
+
+	/**
+	 * Write new content into a config file
+	 *
+	 * @param path the path to config file
+	 * @param value the value to write
+	 */
+	void write(Path path, Object value);
+}

--- a/src/main/java/org/springframework/up/support/configfile/UserConfig.java
+++ b/src/main/java/org/springframework/up/support/configfile/UserConfig.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.up.support.configfile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.function.Function;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Represents a single config file as a yml format.
+ *
+ * @author Janne Valkealahti
+ */
+public class UserConfig<T> {
+
+	private final static String XDG_CONFIG_HOME = "XDG_CONFIG_HOME";
+	private final static String APP_DATA = "APP_DATA";
+	private Function<String, Path> pathProvider = (path) -> Paths.get(path);
+	private final String name;
+	private final ConfigFile file;
+	private final Class<T> type;
+	private final String configDirEnv;
+	private final String configDirName;
+
+	public UserConfig(String name, Class<T> type, String configDirEnv, String configDirName) {
+		Assert.notNull(name, "name must be set");
+		Assert.notNull(type, "type must be set");
+		Assert.notNull(configDirEnv, "config dir env variable must be set");
+		Assert.notNull(configDirName, "config dir name must be set");
+		this.name = name;
+		this.file = new YamlConfigFile();
+		this.type = type;
+		this.configDirEnv = configDirEnv;
+		this.configDirName = configDirName;
+	}
+
+	public T getConfig() {
+		Path path = getConfigDir().resolve(name);
+		if (!Files.exists(path)) {
+			return null;
+		}
+		return file.read(path, type);
+	}
+
+	public void setConfig(T config) {
+		Path path = getConfigDir().resolve(name);
+		try {
+			Files.createDirectories(path.getParent());
+		} catch (IOException e) {
+		}
+		file.write(path, config);
+	}
+
+	/**
+	 * Sets a path provider.
+	 *
+	 * @param pathProvider the path provider
+	 */
+	public void setPathProvider(Function<String, Path> pathProvider) {
+		this.pathProvider = pathProvider;
+	}
+
+	private Path getConfigDir() {
+		Path path;
+		if (StringUtils.hasText(System.getenv(configDirEnv))) {
+			path = pathProvider.apply(System.getenv(configDirEnv));
+		}
+		else if (StringUtils.hasText(System.getenv(XDG_CONFIG_HOME))) {
+			path = pathProvider.apply(System.getProperty(XDG_CONFIG_HOME)).resolve(configDirName);
+		}
+		else if (isWindows() && StringUtils.hasText(System.getenv(APP_DATA))) {
+			path = pathProvider.apply(System.getProperty(APP_DATA)).resolve(configDirName);
+		}
+		else {
+			path = pathProvider.apply(System.getProperty("user.home")).resolve(".config").resolve(configDirName);
+		}
+		return path;
+	}
+
+	private boolean isWindows() {
+		String os = System.getProperty("os.name");
+		return os.startsWith("Windows");
+	}
+}

--- a/src/main/java/org/springframework/up/support/configfile/YamlConfigFile.java
+++ b/src/main/java/org/springframework/up/support/configfile/YamlConfigFile.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.up.support.configfile;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+public class YamlConfigFile implements ConfigFile {
+
+	private ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+	@Override
+	public <T> T read(Path path, Class<T> type) {
+		try {
+			InputStream in = new DataInputStream(Files.newInputStream(path));
+			return mapper.readValue(in, type);
+		} catch (Exception e) {
+			throw new RuntimeException("Unable to read", e);
+		}
+	}
+
+	@Override
+	public void write(Path path, Object value) {
+		try {
+			OutputStream out = new DataOutputStream(Files.newOutputStream(path));
+			mapper.writeValue(out, value);
+		} catch (Exception e) {
+			throw new RuntimeException("Unable to write", e);
+		}
+	}
+}

--- a/src/main/java/org/springframework/up/support/github/GithubDeviceFlow.java
+++ b/src/main/java/org/springframework/up/support/github/GithubDeviceFlow.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.up.support.github;
+
+import java.time.Duration;
+import java.util.Map;
+
+import reactor.core.publisher.Mono;
+import reactor.retry.Backoff;
+import reactor.util.retry.Retry;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Utility methods for github auth flows.
+ *
+ * @author Janne Valkealahti
+ */
+public abstract class GithubDeviceFlow {
+
+	private final static ParameterizedTypeReference<Map<String, String>> RESPONSE_TYPE_REFERENCE =
+			new ParameterizedTypeReference<Map<String, String>>() {};
+
+	/**
+	 * Starts a device flow. Makes a simple request to github api to request new
+	 * device code which user can use to complete authentication process.
+	 *
+	 * @param webClientBuilder the web client builder
+	 * @param clientId the client id
+	 * @param scope the scopes
+	 * @return Map of response values
+	 */
+	public static Map<String, String> requestDeviceFlow(WebClient.Builder webClientBuilder, String clientId, String scope) {
+		WebClient client = webClientBuilder
+			.baseUrl("https://github.com")
+			.build();
+		Mono<Map<String, String>> response = client.post()
+			.uri(uriBuilder -> uriBuilder
+					.path("login/device/code")
+					.queryParam("client_id", clientId)
+					.queryParam("scope", scope)
+					.build())
+			.accept(MediaType.APPLICATION_JSON)
+			.retrieve().bodyToMono(RESPONSE_TYPE_REFERENCE);
+		Map<String, String> values = response.block();
+		return values;
+	}
+
+	/**
+	 * Waits user to enter code based on info api gave us from initial device flow request.
+	 *
+	 * @param clientId the client id
+	 * @param deviceCode the device code
+	 * @param timeout the timeout
+	 * @param interval the interval
+	 * @return a token
+	 */
+	public static String waitTokenFromDeviceFlow(WebClient.Builder webClientBuilder, String clientId, String deviceCode,
+			int timeout, int interval) {
+		WebClient client = webClientBuilder
+			.baseUrl("https://github.com")
+			.build();
+		Mono<String> accessToken = client.post()
+			.uri(uriBuilder -> uriBuilder
+					.path("login/oauth/access_token")
+					.queryParam("client_id", clientId)
+					.queryParam("device_code", deviceCode)
+					.queryParam("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+					.build())
+			.accept(MediaType.APPLICATION_JSON)
+			.exchangeToMono(response -> {
+				return response.bodyToMono(RESPONSE_TYPE_REFERENCE);
+			})
+			.flatMap(data -> {
+				String token = data.get("access_token");
+				if (StringUtils.hasText(token)) {
+					return Mono.just(token);
+				}
+				else {
+					return Mono.error(new NoAccessTokenException());
+				}
+			})
+			.retryWhen(Retry.withThrowable(reactor.retry.Retry.onlyIf(x -> {
+					if (x.exception() instanceof NoAccessTokenException) {
+						return true;
+					}
+					else {
+						return false;
+					}
+				})
+				.timeout(Duration.ofSeconds(timeout))
+				.backoff(Backoff.fixed(Duration.ofSeconds(interval)))
+			));
+			return accessToken.block();
+	}
+
+	/**
+	 * Used in a reactor chain to retry when poll/retry request don't
+	 * yet have a token.
+	 */
+	private static class NoAccessTokenException extends RuntimeException {
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,9 @@ spring:
       version:
         show-git-short-commit-id: true
   up:
+    github:
+      client-id: e4983cc3c5a6a2066b63
+      default-scopes: repo,read:org
     templateCatalogs:
       - name: catalog1
         description: The first catalog

--- a/src/test/java/org/springframework/up/config/UpCliPropertiesTests.java
+++ b/src/test/java/org/springframework/up/config/UpCliPropertiesTests.java
@@ -33,6 +33,8 @@ public class UpCliPropertiesTests {
 				.run((context) -> {
 					UpCliProperties properties = context.getBean(UpCliProperties.class);
 					assertThat(properties.getInitializr().getBaseUrl()).isEqualTo("https://start.spring.io");
+					assertThat(properties.getGithub().getClientId()).isNull();
+					assertThat(properties.getGithub().getDefaultScopes()).isEqualTo("repo,read:org");
 				});
 	}
 
@@ -40,10 +42,14 @@ public class UpCliPropertiesTests {
 	public void setProperties() {
 		this.contextRunner
 				.withPropertyValues("spring.up.initializr.base-url=fakeurl")
+				.withPropertyValues("spring.up.github.client-id=fakeid")
+				.withPropertyValues("spring.up.github.default-scopes=fakescopes")
 				.withUserConfiguration(Config1.class)
 				.run((context) -> {
 					UpCliProperties properties = context.getBean(UpCliProperties.class);
 					assertThat(properties.getInitializr().getBaseUrl()).isEqualTo("fakeurl");
+					assertThat(properties.getGithub().getClientId()).isEqualTo("fakeid");
+					assertThat(properties.getGithub().getDefaultScopes()).isEqualTo("fakescopes");
 				});
 	}
 

--- a/src/test/java/org/springframework/up/support/UpCliUserConfigTests.java
+++ b/src/test/java/org/springframework/up/support/UpCliUserConfigTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.up.support;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import com.google.common.jimfs.Jimfs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UpCliUserConfigTests {
+
+	private FileSystem fileSystem;
+	private Function<String, Path> pathProvider;
+
+	@BeforeEach
+	public void setupTests() {
+		fileSystem = Jimfs.newFileSystem();
+		pathProvider = (path) -> fileSystem.getPath(path);
+	}
+
+	@Test
+	public void test() {
+		UpCliUserConfig config = new UpCliUserConfig(pathProvider);
+		UpCliUserConfig.Hosts hosts = new UpCliUserConfig.Hosts();
+		Map<String, UpCliUserConfig.Host> hostsMap = new HashMap<>();
+		hostsMap.put("github.com", new UpCliUserConfig.Host("faketoken", "user"));
+		hosts.setHosts(hostsMap);
+		config.setHosts(hosts);
+		assertThat(config.getHosts()).isNotNull();
+		assertThat(config.getHosts().get("github.com")).isNotNull();
+		assertThat(config.getHosts().get("github.com").getOauthToken()).isEqualTo("faketoken");
+	}
+}

--- a/src/test/java/org/springframework/up/support/configfile/UserConfigTests.java
+++ b/src/test/java/org/springframework/up/support/configfile/UserConfigTests.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.up.support.configfile;
+
+import org.junit.jupiter.api.Test;
+
+public class UserConfigTests {
+
+	@Test
+	public void test() {
+	}
+}

--- a/src/test/java/org/springframework/up/support/configfile/YamlConfigFileTests.java
+++ b/src/test/java/org/springframework/up/support/configfile/YamlConfigFileTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.up.support.configfile;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class YamlConfigFileTests {
+
+	@Test
+	public void testReadWrite(@TempDir Path tempDir) {
+		Path file = tempDir.resolve("file.yml");
+		YamlConfigFile yamlConfigFile = new YamlConfigFile();
+		yamlConfigFile.write(file, Bean1.of("value1", "key2", "value2"));
+		Bean1 bean = yamlConfigFile.read(file, Bean1.class);
+		assertThat(bean.getValue()).isEqualTo("value1");
+		assertThat(bean.getValues()).containsEntry("key2", "value2");
+	}
+
+	private static class Bean1 {
+
+		private String value;
+		private Map<String, String> values;
+
+		static Bean1 of(String value, String valuesKey, String valuesValue) {
+			Bean1 bean = new Bean1();
+			bean.setValue(value);
+			Map<String, String> values = new HashMap<>();
+			values.put(valuesKey, valuesValue);
+			bean.setValues(values);
+			return bean;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
+
+		public Map<String, String> getValues() {
+			return values;
+		}
+
+		public void setValues(Map<String, String> values) {
+			this.values = values;
+		}
+	}
+}


### PR DESCRIPTION
- New commands `login`, `logout` and `status` under `github auth`.
- Config file subsystem to easily write/read pojos as a user level
  config files using yaml structure where things are handled via jackson.
- Add masking method to wizard.
- Update native configs.
- OAuth app from my settings until we get more permanent location.
- Fixes #2
- Fixes #3